### PR TITLE
feat: add version control provider

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 from src.app_updater import AppUpdater
+from src.version_control_provider import CoreConfigProvider
 
-if __name__ == '__main__':
-    AppUpdater().update_source_code_automaticaly()
+if __name__ == "__main__":
+    AppUpdater(version_control_provider=CoreConfigProvider).update_source_code_automaticaly()

--- a/src/app_updater.py
+++ b/src/app_updater.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import subprocess
 import traceback
-import yaml
+from src.version_control_provider import LocalConfigProvider, VersionControlProvider
 
 from src.email_sender import EmailSender
 from .github_repository import GithubRepository
@@ -11,10 +11,9 @@ class AppUpdater:
     max_input_retries = 3
     organization_name = "core-webapp"
     repository_name = "core_legacy"
-    user_input_true = 'y'
-    license_path = Path() / repository_name / 'state' / 'utils' / 'license.yaml'
-    requirements_path = Path() / repository_name / 'requirements.txt'
-    config_file_path = Path() / '.config.yaml'
+    user_input_true = "y"
+    license_path = Path() / repository_name / "state" / "utils" / "license.yaml"
+    requirements_path = Path() / repository_name / "requirements.txt"
 
     # TODO where should we add the developers? harcoded here or in a config file?
     developers: tuple[str]
@@ -25,21 +24,12 @@ class AppUpdater:
 
     changes_made = []
 
-    def __init__(self) -> None:
-        self.config = self.get_config_from_file()
-
-    @property
-    def local_repository_path(self) -> Path:
-        return Path(self.config.get('local_repository_path'))
-
-    def get_config_from_file(self) -> None:
-        with open(self.config_file_path, 'rb') as file:
-            raw_yaml_config = file.read()
-            config = yaml.safe_load(raw_yaml_config)
-        return config
+    def __init__(
+        self, version_control_provider: VersionControlProvider = LocalConfigProvider
+    ) -> None:
+        self.version_control_provider = version_control_provider()
 
     def install_source_code(self):
-
         # TODO: get token from user and if it is valid continue
 
         # TODO: clone the repository in the directory where is present the app_updater
@@ -57,31 +47,25 @@ class AppUpdater:
         # TODO: send mail with a resume of the new changes
         pass
 
-    def update_source_code_automaticaly(self):
-
-        token = self._get_api_token()
+    def update_source_code_automaticaly(self) -> None:
+        version_control_data = self.version_control_provider.get_config()
         github_repository = GithubRepository(
-            token,
+            version_control_data["token"],
             self.organization_name,
-            self.local_repository_path,
+            version_control_data["local_repository_path"],
             self.repository_name,
         )
 
-        version_tag = self._get_version_tag_to_update()
-        self._update_to_new_version(github_repository, version_tag)
+        self._update_to_new_version(github_repository, version_control_data["version"])
 
         # self._install_dependencies_from_requirements()
 
         # self._run_database_migration()
         # self._send_email_with_resume_of_changes()
 
-    def _get_api_token(self) -> str:
-        return self.config.get('token')
-
-    def _get_version_tag_to_update(self) -> str:
-        return self.config.get('version')
-
-    def _update_to_new_version(self, github_repository: GithubRepository, version_tag: str = 'qa') -> None:
+    def _update_to_new_version(
+        self, github_repository: GithubRepository, version_tag: str = "qa"
+    ) -> None:
         version_commit = github_repository.get_commit_sha_of_version_tag(version_tag)
         github_repository.change_source_code_version(version_commit)
         self._log_change(
@@ -103,10 +87,9 @@ class AppUpdater:
             traceback.print_exc()
 
     def _send_email_with_resume_of_changes(self):
-
         changes_made = self.changes_made
 
         email_sender = EmailSender()
 
         for user_target in self.developers:
-            email_sender.send_email(user_target, 'actualizacion Core', changes_made)
+            email_sender.send_email(user_target, "actualizacion Core", changes_made)

--- a/src/github_repository.py
+++ b/src/github_repository.py
@@ -10,7 +10,6 @@ from git import Repo
 
 
 class GithubRepository:
-
     def __init__(
         self,
         api_token: str,
@@ -18,7 +17,6 @@ class GithubRepository:
         local_repository_path: Path,
         repository_name: str,
     ) -> None:
-
         self.api_token = api_token
         self.organizacion_name = organizacion_name
         self.repository_name = repository_name
@@ -26,7 +24,9 @@ class GithubRepository:
         self.source_code_path = local_repository_path
 
         self.github_account = self._get_github_account(self.api_token)
-        self.repository = self.github_account.get_repo(f'{self.organizacion_name}/{self.repository_name}')
+        self.repository = self.github_account.get_repo(
+            f"{self.organizacion_name}/{self.repository_name}"
+        )
 
         last_release = self._get_last_release()
         commit_sha = self._get_commit_sha_of_release(last_release)
@@ -40,11 +40,11 @@ class GithubRepository:
 
     @property
     def last_release(self) -> str:
-        return self.version_info.get('last_release')
+        return self.version_info.get("last_release")
 
     @property
     def commit_of_last_release(self) -> str:
-        return self.version_info.get('commit_sha')
+        return self.version_info.get("commit_sha")
 
     @classmethod
     def _is_token_valid(cls, token: str) -> bool:
@@ -73,7 +73,9 @@ class GithubRepository:
         return release_commit.object.sha
 
     def _clone_repository(self, repository_url: str, path_to_clone_the_app: str):
-        repo_url_with_token = repository_url.replace('https://', f'https://{self.api_token}@')
+        repo_url_with_token = repository_url.replace(
+            "https://", f"https://{self.api_token}@"
+        )
         Repo.clone_from(repo_url_with_token, path_to_clone_the_app)
 
     def change_source_code_version(self, commit: str) -> None:

--- a/src/version_control_provider.py
+++ b/src/version_control_provider.py
@@ -1,0 +1,78 @@
+from abc import abstractmethod
+import requests
+import os
+import yaml
+from pathlib import Path
+from typing import TypedDict
+
+config_file_path = Path() / ".config.yaml"
+
+
+class VersionControlConfigs(TypedDict):
+    token: str
+    version: str
+    local_repository_path: str
+
+
+class VersionControlProvider:
+    @abstractmethod
+    def get_config(self) -> VersionControlConfigs:
+        raise NotImplementedError()
+
+
+class CoreConfigProvider(VersionControlProvider):
+    BASE_URL = os.getenv("CORE_BE_URL")
+
+    def __init__(self, token=None):
+        self.token = token if token else os.getenv("CORE_BE_TOKEN")
+        super().__init__()
+
+    def get_config(self) -> VersionControlConfigs:
+        config = self._get_version_control_info()
+        return VersionControlConfigs(
+            token=config.get("token"),
+            version=config.get("version"),
+            local_repository_path=Path(config.get("local_repository_path")),
+        )
+
+    def _get_version_control_info(self):
+        url = f"{self.BASE_URL}api/company/version-control/me/"
+        try:
+            response = requests.get(
+                url, headers={"Authorization": f"Token {self.token}"}
+            )
+        except Exception as e:
+            raise Exception(f"There was an error calling to core-be - {e}")
+
+        if response.status_code == 200:
+            return response.json()
+        raise Exception(
+            f"There was an error getting the config - {response.status_code} - {response.reason}"
+        )
+
+
+class LocalConfigProvider(VersionControlProvider):
+    def __init__(self):
+        self.config = self._get_config_file_data()
+
+    def _get_config_file_data(self) -> None:
+        with open(config_file_path, "rb") as file:
+            raw_yaml_config = file.read()
+            config = yaml.safe_load(raw_yaml_config)
+        return config
+
+    def get_config(self) -> VersionControlConfigs:
+        return VersionControlConfigs(
+            token=self._get_api_token(),
+            version=self._get_version_tag_to_update(),
+            local_repository_path=self._get_local_repository_path(),
+        )
+
+    def _get_local_repository_path(self) -> str:
+        return Path(self.config.get("local_repository_path"))
+
+    def _get_api_token(self) -> str:
+        return self.config.get("token")
+
+    def _get_version_tag_to_update(self) -> str:
+        return self.config.get("version")

--- a/test/test_app_updater.py
+++ b/test/test_app_updater.py
@@ -7,6 +7,7 @@ import pytest
 
 from src.app_updater import AppUpdater
 from src.github_repository import GithubRepository
+from src.version_control_provider import VersionControlConfigs, VersionControlProvider
 
 
 @pytest.fixture
@@ -20,22 +21,38 @@ def mock_github_repository() -> GithubRepository:
     return github_repository
 
 
+@pytest.fixture
+def mock_version_control_provider() -> VersionControlProvider:
+    class FakeVersionControlProvider(VersionControlProvider):
+        def get_config(self) -> VersionControlConfigs:
+            return {
+                'token': 'fake_token',
+                'version': 'fake_version',
+                'local_repository_path': 'fake_local_repository_path',
+            }
+    yield FakeVersionControlProvider
+
+
 @patch.object(GithubRepository, 'change_source_code_version')
 @patch.object(GithubRepository, 'get_commit_sha_of_version_tag')
 def test_update_to_new_version(
     patched_get_commit_sha_of_version_tag: MagicMock,
     patched_change_source_code_version: MagicMock,
     mock_github_repository: GithubRepository,
+    mock_version_control_provider: VersionControlProvider,
 ):
     # prepare
     fake_version_tag = 'fake_version_tag'
     fake_version_commit = 'fake_version_commit'
     patched_get_commit_sha_of_version_tag.return_value = fake_version_commit
-    with patch.object(AppUpdater, 'get_config_from_file'):
-        app_updater = AppUpdater()
 
     # test
-    app_updater._update_to_new_version(mock_github_repository, fake_version_tag)
+    AppUpdater(
+        version_control_provider=mock_version_control_provider
+    )._update_to_new_version(
+            mock_github_repository,
+            fake_version_tag,
+        )
 
     # asserts
     mock_github_repository.get_commit_sha_of_version_tag.assert_called_once_with(fake_version_tag)


### PR DESCRIPTION
La intencion fue armar una interface "VersionControlProvider" con dos clases concretas.

Una llama a core-be para obtener las configs
otra usa .config.yaml

Quizá haya algo de overkill pero lo hice para aprender a separar responsabilidades

Acepto suggestions

Requiere unas modificaciones en el script, pero works as expected!



